### PR TITLE
fix: persist scan metadata

### DIFF
--- a/src/test/java/com/ibm/DefaultTestConfiguration.java
+++ b/src/test/java/com/ibm/DefaultTestConfiguration.java
@@ -37,24 +37,27 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @Mock
 @ApplicationScoped
 public class DefaultTestConfiguration implements ITestConfiguration {
-    @NotNull @Override
+    @Nonnull
+    @Override
     public String exampleCbomVersion() {
         return "1.6";
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public String exampleCbomString() {
         return "{\"cbom\":\"The cbom\"}";
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public Scan exampleCbom() {
         try {
             Scan scan = new Scan();
@@ -70,17 +73,20 @@ public class DefaultTestConfiguration implements ITestConfiguration {
         }
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public String exampleGitUrl() {
         return "https://github.com/apache/commons-io";
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public String exampleGitBranch() {
         return "master";
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public String examplePURL() {
         return "pkg:github/apache/commons-io";
     }
@@ -90,12 +96,14 @@ public class DefaultTestConfiguration implements ITestConfiguration {
         throw new UnsupportedOperationException("Override this function in your test class");
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public IScanRepository getCBOMRepository() {
         return new ScanRepository();
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public IScannerManager getScannerManager() {
         // register scanners
         final List<IScanner> registry = new ArrayList<>();
@@ -105,7 +113,7 @@ public class DefaultTestConfiguration implements ITestConfiguration {
     }
 
     @Override
-    public @NotNull List<File> getJavaDependencyJARS() {
+    public @Nonnull List<File> getJavaDependencyJARS() {
         return ConfigProvider.getConfig()
                 .getOptionalValue("service.scanning.java-jar-dir", String.class)
                 .flatMap(Utils::getJarFiles)

--- a/src/test/java/com/ibm/resources/v1/ScannerResourceTest.java
+++ b/src/test/java/com/ibm/resources/v1/ScannerResourceTest.java
@@ -129,25 +129,25 @@ class ScannerResourceTest extends TestBase {
     void testStoreCbom() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode cbomJson = mapper.readTree(this.testConfiguration.exampleCbomString());
-        final IdentifiersInternal ii =
+        final IdentifiersInternal identifiers =
                 new IdentifiersInternal(
                         this.testConfiguration.exampleGitUrl(),
                         List.of(this.testConfiguration.examplePURL()));
 
-        ScannerResource sr = new ScannerResource(this.testConfiguration);
-        sr.storeCBOM(
-                cbomJson,
-                ii,
-                this.testConfiguration.exampleGitUrl(),
-                this.testConfiguration.exampleGitBranch());
+        ScanRequest request =
+                new ScanRequest(
+                        this.testConfiguration.exampleGitUrl(),
+                        this.testConfiguration.exampleGitBranch(),
+                        null);
+        ScannerResource resource = new ScannerResource(this.testConfiguration);
+        resource.storeCBOM(cbomJson, identifiers, request, "01abcdef");
 
         PanacheQuery<Scan> query =
-                Scan.find(
-                        "gitUrl = ?1 and branch = ?2",
-                        this.testConfiguration.exampleGitUrl(),
-                        this.testConfiguration.exampleGitBranch());
-        Scan cb = query.firstResult();
-        Assertions.assertNotNull(cb);
-        Assertions.assertEquals(cbomJson, cb.getBom());
+                Scan.find("gitUrl = ?1 and branch = ?2", request.gitUrl(), request.branch());
+        Scan scan = query.firstResult();
+        Assertions.assertNotNull(scan);
+        Assertions.assertEquals(request.gitUrl(), scan.getGitUrl());
+        Assertions.assertEquals(request.branch(), scan.getBranch());
+        Assertions.assertEquals(cbomJson, scan.getBom());
     }
 }


### PR DESCRIPTION
Persist scan metadata (giturl, branch, subdir, commitHash, purls) as part of to CBOM metadata properties. Fixes issue #37. 