### PR TITLE
fixed compliance logs, nonnull annotations, testing

### DIFF
--- a/src/main/java/com/ibm/compliance/BasicQuantumSafeComplianceService.java
+++ b/src/main/java/com/ibm/compliance/BasicQuantumSafeComplianceService.java
@@ -30,11 +30,11 @@ import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Component.Type;
 import org.cyclonedx.model.component.crypto.AlgorithmProperties;
 import org.cyclonedx.model.component.crypto.CryptoProperties;
+import org.cyclonedx.model.component.crypto.enums.AssetType;
 import org.cyclonedx.model.component.crypto.enums.Primitive;
 import org.cyclonedx.parsers.BomParserFactory;
 import org.cyclonedx.parsers.Parser;
 import org.jboss.logging.Logger;
-import org.jetbrains.annotations.NotNull;
 
 public class BasicQuantumSafeComplianceService implements IComplianceService {
     private static final Logger LOG = Logger.getLogger(BasicQuantumSafeComplianceService.class);
@@ -113,8 +113,7 @@ public class BasicQuantumSafeComplianceService implements IComplianceService {
     }
 
     @Nonnull
-    public @NotNull ComplianceFormat check(
-            @Nonnull String policyIdentifier, @Nonnull String cbomString) {
+    public ComplianceFormat check(@Nonnull String policyIdentifier, @Nonnull String cbomString) {
         if (!policyIdentifier.equals(Policies.QUANTUM_SAFE.toString())) {
             LOG.warn(
                     this.getClass().getSimpleName()
@@ -136,7 +135,10 @@ public class BasicQuantumSafeComplianceService implements IComplianceService {
                     .filter(
                             component ->
                                     component.getBomRef() != null
-                                            && component.getType() == Type.CRYPTOGRAPHIC_ASSET)
+                                            && component.getType() == Type.CRYPTOGRAPHIC_ASSET
+                                            && component.getCryptoProperties() != null
+                                            && component.getCryptoProperties().getAssetType()
+                                                    == AssetType.ALGORITHM)
                     .forEach(
                             component -> {
                                 final ComplianceFormat.ComplianceFinding finding =
@@ -163,12 +165,6 @@ public class BasicQuantumSafeComplianceService implements IComplianceService {
     private ComplianceFormat.ComplianceFinding getCompliance(@Nonnull Component component) {
         final String bomRef = component.getBomRef();
         final CryptoProperties cryptoProperties = component.getCryptoProperties();
-        if (cryptoProperties == null) {
-            return new ComplianceFormat.ComplianceFinding(
-                    bomRef,
-                    2,
-                    "The field 'cryptoProperties' was not set, which does not allow further categorization");
-        }
         final AlgorithmProperties algorithmProperties = cryptoProperties.getAlgorithmProperties();
         if (algorithmProperties == null) {
             return new ComplianceFormat.ComplianceFinding(

--- a/src/main/java/com/ibm/compliance/ibmregulator/IBMRegulatorClient.java
+++ b/src/main/java/com/ibm/compliance/ibmregulator/IBMRegulatorClient.java
@@ -26,8 +26,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import javax.annotation.Nonnull;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.jetbrains.annotations.NotNull;
 
 @RegisterRestClient(configKey = "regulator-api")
 public interface IBMRegulatorClient {
@@ -45,8 +45,9 @@ public interface IBMRegulatorClient {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/policies/{policyName}/target")
-    @NotNull String check(
-            @PathParam("policyName") @NotNull String policyIdentifier, @NotNull String cbomString);
+    @Nonnull
+    String check(
+            @PathParam("policyName") @Nonnull String policyIdentifier, @Nonnull String cbomString);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/ibm/compliance/ibmregulator/IBMRegulatorService.java
+++ b/src/main/java/com/ibm/compliance/ibmregulator/IBMRegulatorService.java
@@ -28,26 +28,25 @@ import com.ibm.compliance.IComplianceService;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.jetbrains.annotations.NotNull;
 
 public class IBMRegulatorService implements IComplianceService {
 
     @Nonnull private final IBMRegulatorClient client;
     @Nonnull private static final String COMPLIANCE_SERVICE_NAME = "IBM Regulator";
 
-    public IBMRegulatorService(@NotNull IBMRegulatorClient client) {
+    public IBMRegulatorService(@Nonnull IBMRegulatorClient client) {
         this.client = client;
     }
 
     @Override
-    public @NotNull ComplianceFormat check(
-            @NotNull String policyIdentifier, @NotNull String cbomString) {
+    public @Nonnull ComplianceFormat check(
+            @Nonnull String policyIdentifier, @Nonnull String cbomString) {
         String res = client.check(policyIdentifier, cbomString);
         return parse(res);
     }
 
     // Better use an ObjectMapper based on the regulator model classes (if open-sourced)
-    private @NotNull ComplianceFormat parse(String jsonString) {
+    private @Nonnull ComplianceFormat parse(String jsonString) {
         ObjectMapper mapper = new ObjectMapper();
         try {
             JsonNode rootNode = mapper.readTree(jsonString);

--- a/src/main/java/com/ibm/configuration/Configuration.java
+++ b/src/main/java/com/ibm/configuration/Configuration.java
@@ -40,9 +40,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @ApplicationScoped
 public final class Configuration implements IConfiguration {
@@ -72,12 +72,14 @@ public final class Configuration implements IConfiguration {
         }
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public IScanRepository getCBOMRepository() {
         return new ScanRepository();
     }
 
-    @NotNull @Override
+    @Nonnull
+    @Override
     public IScannerManager getScannerManager() {
         // register scanners
         final List<IScanner> registry = new ArrayList<>();
@@ -97,7 +99,7 @@ public final class Configuration implements IConfiguration {
     }
 
     @Override
-    public @NotNull List<File> getJavaDependencyJARS() {
+    public @Nonnull List<File> getJavaDependencyJARS() {
         return ConfigProvider.getConfig()
                 .getOptionalValue("service.scanning.java-jar-dir", String.class)
                 .flatMap(Utils::getJarFiles)

--- a/src/main/java/com/ibm/model/PurlVersion.java
+++ b/src/main/java/com/ibm/model/PurlVersion.java
@@ -26,7 +26,7 @@ import jakarta.persistence.Id;
 
 @Entity
 @Cacheable
-public final class PurlVersion extends PanacheEntityBase {
+public class PurlVersion extends PanacheEntityBase {
     // id is fixed to 1.
     // There at most one such record which will be
     // overwritten if a new purl version was detected

--- a/src/main/java/com/ibm/model/Scan.java
+++ b/src/main/java/com/ibm/model/Scan.java
@@ -28,7 +28,7 @@ import org.hibernate.type.SqlTypes;
 
 @Entity
 @Cacheable
-public final class Scan extends PanacheEntity {
+public class Scan extends PanacheEntity {
     private String gitUrl;
     private String branch;
     private String cbomSpecVersion;

--- a/src/main/java/com/ibm/repository/ScanRepository.java
+++ b/src/main/java/com/ibm/repository/ScanRepository.java
@@ -36,14 +36,13 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("java:S3252")
 @ApplicationScoped
 public class ScanRepository implements IScanRepository, PanacheRepository<Scan> {
 
     @Transactional
-    public @NotNull Optional<Scan> findByPurl(@Nonnull String purl, @Nullable String cbomVersion) {
+    public @Nonnull Optional<Scan> findByPurl(@Nonnull String purl, @Nullable String cbomVersion) {
         PanacheQuery<IdentifiableScan> query = IdentifiableScan.find("purl", purl);
         IdentifiableScan identifiableScan1 = query.firstResult();
         if (identifiableScan1 != null) {
@@ -56,35 +55,35 @@ public class ScanRepository implements IScanRepository, PanacheRepository<Scan> 
     }
 
     @Transactional
-    public @NotNull Optional<Scan> findByPurl(
+    public @Nonnull Optional<Scan> findByPurl(
             @Nonnull PackageURL purl, @Nullable String cbomVersion) {
         return findByPurl(purl.toString(), cbomVersion);
     }
 
     @Transactional
-    public @NotNull List<Scan> getLastCBOMs(int limit) {
+    public @Nonnull List<Scan> getLastCBOMs(int limit) {
         Sort byCreatedAt = Sort.by("createdAt", Direction.Descending);
         PanacheQuery<Scan> query = Scan.findAll(byCreatedAt).page(Page.ofSize(limit));
         return query.firstPage().list();
     }
 
     @Transactional
-    public @NotNull List<String> findRepositoriesIncludingComponentWithAlgorithmName(
-            @NotNull String algorithm, int limit) {
+    public @Nonnull List<String> findRepositoriesIncludingComponentWithAlgorithmName(
+            @Nonnull String algorithm, int limit) {
         final String sql =
                 "select distinct(gitUrl), createdAt from scan, jsonb_array_elements(bom->'components') c where c->>'name' = ? and c->'cryptoProperties'->>'assetType'='algorithm' order by createdAt desc limit ?";
         return getQuery(algorithm, limit, sql);
     }
 
     @Transactional
-    public @NotNull List<String> findRepositoriesIncludingComponentWithOID(
-            @NotNull String oid, int limit) {
+    public @Nonnull List<String> findRepositoriesIncludingComponentWithOID(
+            @Nonnull String oid, int limit) {
         final String sql =
                 "select distinct(gitUrl), createdAt from scan, jsonb_array_elements(bom->'components') c where c->'cryptoProperties'->>'oid' = ? and c->'cryptoProperties'->>'assetType'='algorithm' order by createdAt desc limit ?";
         return getQuery(oid, limit, sql);
     }
 
-    @NotNull private List<String> getQuery(String searchString, int limit, String sql) {
+    private @Nonnull List<String> getQuery(String searchString, int limit, String sql) {
         Query query = Scan.getEntityManager().createNativeQuery(sql);
         query.setParameter(1, searchString);
         query.setParameter(2, limit);

--- a/src/main/java/com/ibm/scan/JavaAstScannerExtension.java
+++ b/src/main/java/com/ibm/scan/JavaAstScannerExtension.java
@@ -35,7 +35,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jboss.logging.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.java.AnalysisException;
 import org.sonar.java.AnalysisProgress;
@@ -241,7 +240,7 @@ public class JavaAstScannerExtension extends JavaAstScanner {
     }
 
     @Override
-    public void checkInterrupted(@NotNull Exception e) {
+    public void checkInterrupted(@Nonnull Exception e) {
         Throwable cause = ExceptionUtils.getRootCause(e);
         if (cause instanceof InterruptedException
                 || cause instanceof InterruptedIOException


### PR DESCRIPTION
Only minor changes:
- Fixed issue #52.
- Dropped final attribute for entity classes. This caused warnings such as ```2024-10-16 14:45:48,431 WARN [io.qua.hib.orm.run.pro.ProxyDefinitions] (main) Could not generate an enhanced proxy for entity 'com.ibm.model.Identifiers' (class='com.ibm.model.Identifiers') as it's final. Your application might perform better if we're allowed to extend it.```
- Use only javax.annotation.Nonnull (not jetbrains Notnull)
- Clear db after ScannerResourceTest