### PR TITLE
Update docker-compose.yaml to fix db heathcheck error

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,7 +64,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: [ "CMD", "pg_isready -U postgres" ]
+      test: [ "CMD", "pg_isready -U ${POSTGRESQL_AUTH_USERNAME} -d postgres" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
fix FATAL error messages:
```
2024-11-12 17:08:53.814 UTC [38] LOG:  database system was shut down at 2024-11-12 17:08:53 UTC
2024-11-12 17:08:53.818 UTC [1] LOG:  database system is ready to accept connections
2024-11-12 17:09:06.897 UTC [43] FATAL:  role "postgres" does not exist
2024-11-12 17:09:17.904 UTC [45] FATAL:  role "postgres" does not exist
2024-11-12 17:09:28.931 UTC [48] FATAL:  role "postgres" does not exist
```

`postgres` user isn't created because `POSTGRES_USER=${POSTGRESQL_AUTH_USERNAME}` and `POSTGRESQL_AUTH_USERNAME=cbomkit`. Therefore need to set user as cbomkit (`-U cbomkit`) and database as postgres (`-d postgres`) and then the errors don't occur.