### PR TITLE
Rewrote indexing to create a module per directory

### DIFF
--- a/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
+++ b/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
@@ -284,19 +284,20 @@ public final class ScanProcessManager extends ProcessManager<ScanId, ScanAggrega
             final ScanAggregate scanAggregate =
                     possibleScanAggregate.orElseThrow(() -> new EntityNotFoundById(command.id()));
             this.index = new EnumMap<>(Language.class);
-            // java
-            final JavaIndexService javaIndexService = new JavaIndexService(this.progressDispatcher);
             final File dir =
                     Optional.ofNullable(this.projectDirectory)
                             .orElseThrow(GitCloneResultNotAvailable::new);
+            // java
+            final JavaIndexService javaIndexService =
+                    new JavaIndexService(this.progressDispatcher, dir);
             final List<ProjectModule> javaIndex =
-                    javaIndexService.index(dir, scanAggregate.getPackageFolder());
+                    javaIndexService.index(scanAggregate.getPackageFolder());
             this.index.put(Language.JAVA, javaIndex);
             // python
             final PythonIndexService pythonIndexService =
-                    new PythonIndexService(this.progressDispatcher);
+                    new PythonIndexService(this.progressDispatcher, dir);
             final List<ProjectModule> pythonIndex =
-                    pythonIndexService.index(dir, scanAggregate.getPackageFolder());
+                    pythonIndexService.index(scanAggregate.getPackageFolder());
             this.index.put(Language.PYTHON, pythonIndex);
             // continue with scan
             this.commandBus.send(new ScanCommand(command.id()));

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/IndexingService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/IndexingService.java
@@ -19,15 +19,14 @@
  */
 package com.ibm.usecases.scanning.services.indexing;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.ibm.infrastructure.errors.ClientDisconnected;
 import com.ibm.infrastructure.progress.IProgressDispatcher;
 import com.ibm.infrastructure.progress.ProgressMessage;
 import com.ibm.infrastructure.progress.ProgressMessageType;
 import jakarta.annotation.Nonnull;
-
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -132,8 +131,6 @@ public abstract class IndexingService {
     protected String getProjectIdentifier(@Nonnull File directory) {
         return baseDirectory.toPath().relativize(directory.toPath()).toString();
     }
-
-    abstract boolean isModule(@Nonnull File[] files);
 
     abstract boolean excludeFromIndexing(@Nonnull File file);
 }

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
@@ -22,12 +22,23 @@ package com.ibm.usecases.scanning.services.indexing;
 import com.ibm.infrastructure.progress.IProgressDispatcher;
 import jakarta.annotation.Nonnull;
 import java.io.File;
+import java.util.Arrays;
 
 public final class JavaIndexService extends IndexingService {
 
     public JavaIndexService(
             @Nonnull IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
         super(progressDispatcher, baseDirectory, "java", ".java");
+    }
+
+    @Override
+    boolean isModule(@Nonnull File[] files) {
+        return Arrays.stream(files)
+                .anyMatch(
+                        f ->
+                                f.getName().equals("pom.xml")
+                                        || f.getName().equals("build.gradle")
+                                        || f.getName().equals("build.gradle.kts"));
     }
 
     @Override

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
@@ -22,19 +22,12 @@ package com.ibm.usecases.scanning.services.indexing;
 import com.ibm.infrastructure.progress.IProgressDispatcher;
 import jakarta.annotation.Nonnull;
 import java.io.File;
-import java.util.Arrays;
 
 public final class JavaIndexService extends IndexingService {
 
     public JavaIndexService(
             @Nonnull IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
         super(progressDispatcher, baseDirectory, "java", ".java");
-    }
-
-    @Override
-    boolean isModule(@Nonnull File[] files) {
-        return Arrays.stream(files)
-                .anyMatch(f -> f.getName().equals("pom.xml") || f.getName().equals("build.gradle"));
     }
 
     @Override

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
@@ -26,8 +26,9 @@ import java.util.Arrays;
 
 public final class JavaIndexService extends IndexingService {
 
-    public JavaIndexService(@Nonnull IProgressDispatcher progressDispatcher) {
-        super(progressDispatcher, "java", ".java");
+    public JavaIndexService(
+            @Nonnull IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
+        super(progressDispatcher, baseDirectory, "java", ".java");
     }
 
     @Override

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
@@ -22,20 +22,17 @@ package com.ibm.usecases.scanning.services.indexing;
 import com.ibm.infrastructure.progress.IProgressDispatcher;
 import jakarta.annotation.Nonnull;
 import java.io.File;
-import java.util.Arrays;
 
 public final class PythonIndexService extends IndexingService {
 
-    public PythonIndexService(@Nonnull IProgressDispatcher progressDispatcher) {
-        super(progressDispatcher, "python", ".py");
+    public PythonIndexService(
+            @Nonnull IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
+        super(progressDispatcher, baseDirectory, "python", ".py");
     }
 
     @Override
     boolean isModule(@Nonnull File[] files) {
-        return Arrays.stream(files).anyMatch(f -> f.isDirectory() && f.getName().equals("src"));
-        //                             f.getName().equals("pyproject.toml")
-        //                                     || f.getName().equals("setup.cfg")
-        //                                     || f.getName().equals("setup.py"));
+        return false;
     }
 
     @Override

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
@@ -31,11 +31,6 @@ public final class PythonIndexService extends IndexingService {
     }
 
     @Override
-    boolean isModule(@Nonnull File[] files) {
-        return false;
-    }
-
-    @Override
     boolean excludeFromIndexing(@Nonnull File file) {
         return file.getPath().contains("tests/");
     }

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
@@ -22,12 +22,23 @@ package com.ibm.usecases.scanning.services.indexing;
 import com.ibm.infrastructure.progress.IProgressDispatcher;
 import jakarta.annotation.Nonnull;
 import java.io.File;
+import java.util.Arrays;
 
 public final class PythonIndexService extends IndexingService {
 
     public PythonIndexService(
             @Nonnull IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
         super(progressDispatcher, baseDirectory, "python", ".py");
+    }
+
+    @Override
+    boolean isModule(@Nonnull File[] files) {
+        return Arrays.stream(files)
+                .anyMatch(
+                        f ->
+                                f.getName().equals("pyproject.toml")
+                                        || f.getName().equals("setup.cfg")
+                                        || f.getName().equals("setup.py"));
     }
 
     @Override


### PR DESCRIPTION
Indexing now creates a `ProjectModule` object for each directory of the cloned repo. Such modules are only created if the directory contains src files with `languageFileExension`. The code does not look at any build files anymore to determine modules larger than directories.