### PR TITLE
fixed indexing of modules for java and python

### DIFF
--- a/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
+++ b/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
@@ -266,19 +266,20 @@ public final class ScanProcessManager extends ProcessManager<ScanId, ScanAggrega
             final ScanAggregate scanAggregate =
                     possibleScanAggregate.orElseThrow(() -> new EntityNotFoundById(command.id()));
             this.index = new EnumMap<>(Language.class);
-            // java
-            final JavaIndexService javaIndexService = new JavaIndexService(this.progressDispatcher);
             final File dir =
                     Optional.ofNullable(this.projectDirectory)
                             .orElseThrow(GitCloneResultNotAvailable::new);
+            // java
+            final JavaIndexService javaIndexService =
+                    new JavaIndexService(this.progressDispatcher, dir);
             final List<ProjectModule> javaIndex =
-                    javaIndexService.index(dir, scanAggregate.getPackageFolder().orElse(null));
+                    javaIndexService.index(scanAggregate.getPackageFolder());
             this.index.put(Language.JAVA, javaIndex);
             // python
             final PythonIndexService pythonIndexService =
-                    new PythonIndexService(this.progressDispatcher);
+                    new PythonIndexService(this.progressDispatcher, dir);
             final List<ProjectModule> pythonIndex =
-                    pythonIndexService.index(dir, scanAggregate.getPackageFolder().orElse(null));
+                    pythonIndexService.index(scanAggregate.getPackageFolder());
             this.index.put(Language.PYTHON, pythonIndex);
             // continue with scan
             this.commandBus.send(new ScanCommand(command.id()));

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
@@ -26,14 +26,19 @@ import java.util.Arrays;
 
 public final class JavaIndexService extends IndexingService {
 
-    public JavaIndexService(@Nonnull IProgressDispatcher progressDispatcher) {
-        super(progressDispatcher, "java", ".java");
+    public JavaIndexService(
+            @Nonnull IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
+        super(progressDispatcher, baseDirectory, "java", ".java");
     }
 
     @Override
     boolean isModule(@Nonnull File[] files) {
         return Arrays.stream(files)
-                .anyMatch(f -> f.getName().equals("pom.xml") || f.getName().equals("build.gradle"));
+                .anyMatch(
+                        f ->
+                                f.getName().equals("pom.xml")
+                                        || f.getName().equals("build.gradle")
+                                        || f.getName().equals("build.gradle.kts"));
     }
 
     @Override

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
@@ -26,16 +26,19 @@ import java.util.Arrays;
 
 public final class PythonIndexService extends IndexingService {
 
-    public PythonIndexService(@Nonnull IProgressDispatcher progressDispatcher) {
-        super(progressDispatcher, "python", ".py");
+    public PythonIndexService(
+            @Nonnull IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
+        super(progressDispatcher, baseDirectory, "python", ".py");
     }
 
     @Override
     boolean isModule(@Nonnull File[] files) {
-        return Arrays.stream(files).anyMatch(f -> f.isDirectory() && f.getName().equals("src"));
-        //                             f.getName().equals("pyproject.toml")
-        //                                     || f.getName().equals("setup.cfg")
-        //                                     || f.getName().equals("setup.py"));
+        return Arrays.stream(files)
+                .anyMatch(
+                        f ->
+                                f.getName().equals("pyproject.toml")
+                                        || f.getName().equals("setup.cfg")
+                                        || f.getName().equals("setup.py"));
     }
 
     @Override


### PR DESCRIPTION
Replaces the closed PR #104 and fixes the indexing of python modules (issue #102). There is more freedom for structuring python repos which in some situations caused the old indexer not to produce any scanning input. With this PR, the issue https://github.com/IBM/sonar-cryptography/issues/209 can be reproduced.