### PR TITLE
Downgrade quarkus version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.18.1</quarkus.platform.version>
+    <quarkus.platform.version>3.17.8</quarkus.platform.version>
 
     <sonar.crypto.plugin.version>1.3.5</sonar.crypto.plugin.version>
     <sonar.plugin.api.version>10.14.0.2599</sonar.plugin.api.version>
@@ -85,10 +85,11 @@
       <artifactId>quarkus-config-yaml</artifactId>
     </dependency>
 
-    <!-- Fixes error with quarkus 3.16.4 -->
+    <!-- Fixes error with quarkus 3.17 -->
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
+      <version>1.33</version>
     </dependency>
 
     <dependency>
@@ -146,7 +147,6 @@
       <version>${sonar.plugin.api.impl.version}</version>
     </dependency>
 
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
@@ -158,7 +158,6 @@
       <version>3.27.3</version>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>


### PR DESCRIPTION
Downgrade to quarkus `3.17` since `3.18` crashes without errors.