### PR TITLE
fixed wrong package folder when falling back to master branch

### DIFF
--- a/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
+++ b/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
@@ -207,7 +207,7 @@ public final class ScanProcessManager extends ProcessManager<ScanId, ScanAggrega
                                 this.scanId,
                                 gitUrl.value(),
                                 "master",
-                                scanAggregate.getPackageFolder().toString(),
+                                scanAggregate.getPackageFolder().map(Path::toString).orElse(null),
                                 command.credentials()));
             } else {
                 this.progressDispatcher.send(


### PR DESCRIPTION
If no subdir is given the default strategy is to clone the `main` branch. If `main` doesn't exist we fall back to `master`. In this case the package folder was not properly initialized.