### PR TITLE
upgrade to sonar-cryptography-1.4.2 and giturl normalization

### DIFF
--- a/frontend/src/helpers/scan.js
+++ b/frontend/src/helpers/scan.js
@@ -170,8 +170,10 @@ function setCodeOrigin(gitBranch, gitSubfolder) {
     model.codeOrigin.scanUrl = model.codeOrigin.scanUrl.trim();
     // if it's not a package url
     if (!model.codeOrigin.scanUrl.startsWith("pkg:")) {
-      // remove http if there, to make sure the request uses https
-      model.codeOrigin.scanUrl = model.codeOrigin.scanUrl.replace("http://", "")
+      // normalize scanUrl
+      model.codeOrigin.scanUrl = model.codeOrigin.scanUrl
+          .replace(/^http:\/\//, "")
+          .replace(/.git$/, "");
       if (!model.codeOrigin.scanUrl.startsWith("https://")) {
         model.codeOrigin.scanUrl = "https://" + model.codeOrigin.scanUrl;
       }

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.17.8</quarkus.platform.version>
 
-    <sonar.crypto.plugin.version>1.4.0</sonar.crypto.plugin.version>
+    <sonar.crypto.plugin.version>1.4.2</sonar.crypto.plugin.version>
     <sonar.plugin.api.version>11.1.0.2693</sonar.plugin.api.version>
     <sonar.plugin.api.impl.version>25.2.0.102705</sonar.plugin.api.impl.version>
 

--- a/src/main/java/com/ibm/domain/scanning/GitUrl.java
+++ b/src/main/java/com/ibm/domain/scanning/GitUrl.java
@@ -26,6 +26,13 @@ import java.net.MalformedURLException;
 import java.net.URI;
 
 public record GitUrl(@Nonnull String value) implements IValueObject {
+    // normalize value
+    public GitUrl {
+        value = value.replaceAll(".git$", "").replaceAll("^http://", "");
+        if (!value.startsWith("https://")) {
+            value = "https://" + value;
+        }
+    }
 
     @SuppressWarnings("all")
     @Override

--- a/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
+++ b/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
@@ -136,8 +136,6 @@ public final class ScanProcessManager extends ProcessManager<ScanId, ScanAggrega
 
             // update aggregate
             scanAggregate.setResolvedGitUrl(gitUrl);
-            this.progressDispatcher.send(
-                    new ProgressMessage(ProgressMessageType.GITURL, gitUrl.value()));
 
             if (purl.getType().equals(PackageURL.StandardTypes.GITHUB)) {
                 scanAggregate.setCommitHash(new Commit(purl.getVersion()));
@@ -172,6 +170,8 @@ public final class ScanProcessManager extends ProcessManager<ScanId, ScanAggrega
                         .getGitUrl()
                         .orElseThrow(() -> new NoGitUrlSpecifiedForScan(command.id()));
         try {
+            this.progressDispatcher.send(
+                    new ProgressMessage(ProgressMessageType.GITURL, gitUrl.value()));
             this.progressDispatcher.send(
                     new ProgressMessage(
                             ProgressMessageType.BRANCH, scanAggregate.getRevision().value()));


### PR DESCRIPTION
PR for cbomkit 1.4.2:

- upgrade to sonar-cryptography 1.4.2
- giturl normalization in frontend and backend. Protocol "http -> "https", optional ".git" suffix removed.
- giturl always sent to FE before scan step. Enables code look-up during running scan.
