### PR TITLE
Hotfix: disabled python indexing and scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.17.8</quarkus.platform.version>
+    <quarkus.platform.version>3.19.3</quarkus.platform.version>
 
     <sonar.crypto.plugin.version>1.4.5</sonar.crypto.plugin.version>
     <sonar.plugin.api.version>11.3.0.2824</sonar.plugin.api.version>
@@ -85,12 +85,12 @@
       <artifactId>quarkus-config-yaml</artifactId>
     </dependency>
 
-    <!-- Fixes error with quarkus 3.17 -->
+    <!-- Fixes error with quarkus 3.17 >
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>1.33</version>
-    </dependency>
+    </dependency-->
 
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
+++ b/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
@@ -57,7 +57,6 @@ import com.ibm.usecases.scanning.services.git.CloneResultDTO;
 import com.ibm.usecases.scanning.services.git.GitService;
 import com.ibm.usecases.scanning.services.indexing.JavaIndexService;
 import com.ibm.usecases.scanning.services.indexing.ProjectModule;
-import com.ibm.usecases.scanning.services.indexing.PythonIndexService;
 import com.ibm.usecases.scanning.services.pkg.MavenPackageFinderService;
 import com.ibm.usecases.scanning.services.pkg.SetupPackageFinderService;
 import com.ibm.usecases.scanning.services.pkg.TomlPackageFinderService;
@@ -66,7 +65,6 @@ import com.ibm.usecases.scanning.services.resolve.GithubPurlResolver;
 import com.ibm.usecases.scanning.services.resolve.PurlResolver;
 import com.ibm.usecases.scanning.services.scan.ScanResultDTO;
 import com.ibm.usecases.scanning.services.scan.java.JavaScannerService;
-import com.ibm.usecases.scanning.services.scan.python.PythonScannerService;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.io.File;
@@ -294,11 +292,11 @@ public final class ScanProcessManager extends ProcessManager<ScanId, ScanAggrega
                     javaIndexService.index(scanAggregate.getPackageFolder());
             this.index.put(Language.JAVA, javaIndex);
             // python
-            final PythonIndexService pythonIndexService =
-                    new PythonIndexService(this.progressDispatcher, dir);
-            final List<ProjectModule> pythonIndex =
-                    pythonIndexService.index(scanAggregate.getPackageFolder());
-            this.index.put(Language.PYTHON, pythonIndex);
+            //     final PythonIndexService pythonIndexService =
+            //             new PythonIndexService(this.progressDispatcher, dir);
+            //     final List<ProjectModule> pythonIndex =
+            //             pythonIndexService.index(scanAggregate.getPackageFolder());
+            //     this.index.put(Language.PYTHON, pythonIndex);
             // continue with scan
             this.commandBus.send(new ScanCommand(command.id()));
         } catch (Exception e) {
@@ -374,43 +372,43 @@ public final class ScanProcessManager extends ProcessManager<ScanId, ScanAggrega
                                 javaScanResultDTO.cbom()));
             }
 
-            // python
-            final PythonScannerService pythonScannerService =
-                    new PythonScannerService(
-                            this.progressDispatcher,
-                            Optional.ofNullable(this.projectDirectory)
-                                    .orElseThrow(NoProjectDirectoryProvided::new));
-            final ScanResultDTO pythonScanResultDTO =
-                    pythonScannerService.scan(
-                            gitUrl,
-                            scanAggregate.getRevision(),
-                            commit,
-                            scanAggregate.getPackageFolder().orElse(null),
-                            Optional.ofNullable(this.index)
-                                    .map(i -> i.get(Language.PYTHON))
-                                    .orElseThrow(NoIndexForProject::new));
-            // update statistics
-            numberOfScannedLine += pythonScanResultDTO.numberOfScannedLine();
-            numberOfScannedFiles += pythonScanResultDTO.numberOfScannedFiles();
+            //     // python
+            //     final PythonScannerService pythonScannerService =
+            //             new PythonScannerService(
+            //                     this.progressDispatcher,
+            //                     Optional.ofNullable(this.projectDirectory)
+            //                             .orElseThrow(NoProjectDirectoryProvided::new));
+            //     final ScanResultDTO pythonScanResultDTO =
+            //             pythonScannerService.scan(
+            //                     gitUrl,
+            //                     scanAggregate.getRevision(),
+            //                     commit,
+            //                     scanAggregate.getPackageFolder().orElse(null),
+            //                     Optional.ofNullable(this.index)
+            //                             .map(i -> i.get(Language.PYTHON))
+            //                             .orElseThrow(NoIndexForProject::new));
+            //     // update statistics
+            //     numberOfScannedLine += pythonScanResultDTO.numberOfScannedLine();
+            //     numberOfScannedFiles += pythonScanResultDTO.numberOfScannedFiles();
 
-            if (pythonScanResultDTO.cbom() != null) {
-                // update statistics
-                if (cbom != null) {
-                    cbom.merge(pythonScanResultDTO.cbom());
-                } else {
-                    cbom = pythonScanResultDTO.cbom();
-                }
+            //     if (pythonScanResultDTO.cbom() != null) {
+            //         // update statistics
+            //         if (cbom != null) {
+            //             cbom.merge(pythonScanResultDTO.cbom());
+            //         } else {
+            //             cbom = pythonScanResultDTO.cbom();
+            //         }
 
-                scanAggregate.reportScanResults(
-                        new LanguageScan(
-                                Language.PYTHON,
-                                new ScanMetadata(
-                                        pythonScanResultDTO.startTime(),
-                                        pythonScanResultDTO.endTime(),
-                                        pythonScanResultDTO.numberOfScannedLine(),
-                                        pythonScanResultDTO.numberOfScannedFiles()),
-                                pythonScanResultDTO.cbom()));
-            }
+            //         scanAggregate.reportScanResults(
+            //                 new LanguageScan(
+            //                         Language.PYTHON,
+            //                         new ScanMetadata(
+            //                                 pythonScanResultDTO.startTime(),
+            //                                 pythonScanResultDTO.endTime(),
+            //                                 pythonScanResultDTO.numberOfScannedLine(),
+            //                                 pythonScanResultDTO.numberOfScannedFiles()),
+            //                         pythonScanResultDTO.cbom()));
+            //     }
 
             // publish scan finished and save state
             scanAggregate.scanFinished();


### PR DESCRIPTION
We are currently investigating issue #138 and have determined that it is related to Python scanning. For now, we will disable this feature as a hotfix and investigate further. 

Other updates:
- update quarkus version to `3.19.3`
- remove `snakeyaml` dependency 